### PR TITLE
fix: make github actions work with monorepo structure

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -9,7 +9,7 @@ jobs:
     defaults: 
       run:
         working-directory: frontend
-        
+
     strategy:
       matrix:
         node-version: [16.x]
@@ -32,8 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Run linters
-        run: yarn lint
-
+      - name: Build project
+        run: yarn build
         env:
           CI: true

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -3,9 +3,13 @@ name: Production Build
 on: [push]
 
 jobs:
-  build:
+  build-frontend:
     runs-on: ubuntu-latest
 
+    defaults: 
+      run:
+        working-directory: frontend
+        
     strategy:
       matrix:
         node-version: [16.x]

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -2,7 +2,7 @@ name: Lint
 on: [push]
 
 jobs:
-  run-linters:
+  run-linters-frontend:
     name: Run Linters
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

Changed the default working directories of our github actions to work with frontend and backend being in separate folders from within our workflows yml files.
