### PR TITLE
fixes indent rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -23,10 +23,6 @@ module.exports = {
   },
   plugins: ['import', 'react', '@typescript-eslint'],
   rules: {
-    // A few more opinions in addition to extensions
-    indent: 'off',
-    '@typescript-eslint/indent': 'off',
-
     // As per React 17 changes! https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
     'react/react-in-jsx-scope': 'off',
     'react/jsx-uses-react': 'off',

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   rules: {
     // A few more opinions in addition to extensions
     indent: 'off',
+    '@typescript-eslint/indent': 'off',
 
     // As per React 17 changes! https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
     'react/react-in-jsx-scope': 'off',
@@ -37,9 +38,6 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 'off',
 
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-
-    // 2 space indentation
-    '@typescript-eslint/indent': ['error', 2],
 
     // Style
     quotes: ['error', 'single', { avoidEscape: true }],

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
   plugins: ['import', 'react', '@typescript-eslint'],
   rules: {
     // A few more opinions in addition to extensions
-    "indent": "off",
+    indent: 'off',
 
     // As per React 17 changes! https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
     'react/react-in-jsx-scope': 'off',

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -5,15 +5,7 @@ import { HeaderSections } from './shared/globalTypes';
 import '../assets/WestwoodSans-Regular.ttf';
 
 class NameForm extends React.Component<
-  any,
-  {
-    Title: string;
-    sDate: string;
-    Description: string;
-    sTime: string;
-    eDate: string;
-    eTime: string;
-  }
+any,{Title: string;sDate: string;Description: string;sTime: string;eDate: string;eTime: string;}
 > {
   constructor(props: any) {
     super(props);

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -5,7 +5,15 @@ import { HeaderSections } from './shared/globalTypes';
 import '../assets/WestwoodSans-Regular.ttf';
 
 class NameForm extends React.Component<
-any,{Title: string;sDate: string;Description: string;sTime: string;eDate: string;eTime: string;}
+  any,
+  {
+    Title: string;
+    sDate: string;
+    Description: string;
+    sTime: string;
+    eDate: string;
+    eTime: string;
+  }
 > {
   constructor(props: any) {
     super(props);


### PR DESCRIPTION
Turns out the lines can just be removed, and the `eslint-config-prettier` plugin automatically catches it so these rules are irrelevant